### PR TITLE
Update ray-values.yaml

### DIFF
--- a/kubernetes/terraform/kuberay/README.md
+++ b/kubernetes/terraform/kuberay/README.md
@@ -17,9 +17,42 @@ export NCP_FOLDER_ID=$(ncp config get folder-id)
 ```
 
 ## kuberay module installation steps
-* Important note! *
+### Prerequisites
+1. Important note! 
  Avoid deploying K8s cluster with kuberay simultanouasly from scratch, instead, start with deploying K8s cluster, only then, when the cluster is healthy, turn kuberay variable to 'true', and deploy kuberay operator.
-* *
+
+
+2. Validate which type of cpu platfroms generated for your environment: Intel Ice Lake (instance-type=standard-v3) / Intel Cascade (instance-type=standard-v2):
+```shell
+kubectl get nodes --show-labels | grep instance-type
+```
+4. In your ray-cluster.yaml, set the worker node selector accordingly(gpu-h100/gpu-h100-b/c):
+gpu-workers(ray-cluster.yaml):
+```shell
+worker:
+...Rest of configs
+    nodeSelector
+        beta.kubernetes.io/instance-type: gpu-h100
+...Rest of configs
+```
+5. In your ray-cluster.yaml, set the head&redis node selector accordingly
+non-gpu pods (the example below based on if your k8s cpu-only ng using Intel Cascade/standard-v2);
+*If your cluster provisioned standard-v3 cpu platform, please change it accordingly:
+```shell
+redis:
+...Rest of configs
+  nodeSelector:
+    beta.kubernetes.io/instance-type: standard-v2
+...Rest of configs
+
+head:
+...Rest of configs
+  nodeSelector:
+    beta.kubernetes.io/instance-type: standard-v2
+...Rest of configs
+```
+
+## Installation
 
 1. To use kuberay as a module, please add the following module call to the end of your root main.tf:
 

--- a/kubernetes/terraform/kuberay/helm/ray-values.yaml
+++ b/kubernetes/terraform/kuberay/helm/ray-values.yaml
@@ -10,7 +10,8 @@ additionalWorkerGroups:
     labels: {}
     maxReplicas: 0
     minReplicas: 0
-    nodeSelector: {}
+    nodeSelector: 
+      beta.kubernetes.io/instance-type: standard-v3
     rayStartParams: {}
     replicas: 0
     resources:
@@ -58,11 +59,14 @@ head:
   containerEnv:
   - name: RAY_REDIS_ADDRESS
     value: '{{ .Release.Name }}-redis-master:6379'
+  - name: NVIDIA_VISIBLE_DEVICES
+    value: "void"
   enableInTreeAutoscaling: true
   envFrom: []
   headService: {}
   labels: {}
-  nodeSelector: {}
+  nodeSelector: 
+    beta.kubernetes.io/instance-type: standard-v3
   rayStartParams:
     dashboard-host: 0.0.0.0
   resources:

--- a/kubernetes/terraform/kuberay/helm/ray-values.yaml
+++ b/kubernetes/terraform/kuberay/helm/ray-values.yaml
@@ -1,6 +1,15 @@
 additionalWorkerGroups:
   cpu:
-    affinity: {}
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+            - key: beta.kubernetes.io/instance-type
+              operator: In
+              values:
+              - standard-v2
     annotations: {}
     args: []
     command: []
@@ -11,7 +20,7 @@ additionalWorkerGroups:
     maxReplicas: 0
     minReplicas: 0
     nodeSelector: 
-      beta.kubernetes.io/instance-type: standard-v3
+      beta.kubernetes.io/instance-type: standard-v2
     rayStartParams: {}
     replicas: 0
     resources:
@@ -31,6 +40,11 @@ additionalWorkerGroups:
     volumes:
     - emptyDir: {}
       name: log-volume
+    tolerations:
+    - key: "beta.kubernetes.io/instance-type"
+      operator: "Equal"
+      value: "standard-v2"
+      effect: "NoSchedule"
 common:
   containerEnv:
   - name: AWS_EC2_METADATA_DISABLED
@@ -40,8 +54,8 @@ fullnameOverride: ""
 gpuPlatform: NVIDIA® H100 NVLink with Intel Sapphire Rapids
 gpuToResourceHelperValues:
   NVIDIA® H100 NVLink with Intel Sapphire Rapids:
-    cpu: 18
-    memory: 145
+    cpu: 20
+    memory: 160
   NVIDIA® H100 PCIe with Intel Ice Lake:
     cpu: 22
     memory: 86
@@ -51,89 +65,7 @@ gpuToResourceHelperValues:
   NVIDIA® V100 PCIe with Intel Broadwell:
     cpu: 3
     memory: 40
-head:
-  affinity: {}
-  annotations: {}
-  args: []
-  command: []
-  containerEnv:
-  - name: RAY_REDIS_ADDRESS
-    value: '{{ .Release.Name }}-redis-master:6379'
-  - name: NVIDIA_VISIBLE_DEVICES
-    value: "void"
-  enableInTreeAutoscaling: true
-  envFrom: []
-  headService: {}
-  labels: {}
-  nodeSelector: 
-    beta.kubernetes.io/instance-type: standard-v3
-  rayStartParams:
-    dashboard-host: 0.0.0.0
-  resources:
-    limits:
-      cpu: "4"
-      memory: 8Gi
-    requests:
-      cpu: '{{ .Values.head.resources.limits.cpu }}'
-      memory: '{{ .Values.head.resources.limits.memory }}'
-  securityContext: {}
-  serviceAccountName: ""
-  sidecarContainers: []
-  tolerations: []
-  volumeMounts:
-  - mountPath: /tmp/ray
-    name: log-volume
-  volumes:
-  - emptyDir: {}
-    name: log-volume
-image:
-  pullPolicy: IfNotPresent
-  repository: cr.nemax.nebius.cloud/yc-marketplace/nebius/ray-cluster/rayproject/ray-ml1713900777304275129011842529120435612759099215098
-  tag: 2.9.3-gpu
-imagePullSecrets: []
-kuberay-operator:
-  image:
-    pullPolicy: IfNotPresent
-    repository: cr.nemax.nebius.cloud/yc-marketplace/nebius/ray-cluster/kuberay/operator1713900777304275129011842529120435612759099215098
-    tag: v1.1.0
-  singleNamespaceInstall: true
-nameOverride: kuberay
-redis:
-  architecture: standalone
-  auth:
-    enabled: false
-  image:
-    pullPolicy: IfNotPresent
-    registry: cr.nemax.nebius.cloud/yc-marketplace
-    repository: nebius/ray-cluster/redis1713900777304275129011842529120435612759099215098
-    tag: 7.2.4-debian-12-r9
-  master:
-    persistence:
-      size: 8Gi
-      storageClass: nebius-network-ssd
-    persistentVolumeClaimRetentionPolicy:
-      enabled: true
-      whenDeleted: Delete
-      whenScaled: Retain
-    resources:
-      limits:
-        cpu: "4" # limits Minimum cpu=4 per gpu node
-        memory: 8Gi # limits Minimum memory=8Gi per gpu node
-      requests:
-        cpu: "1" # Requests Minimum cpu=1 per gpu node
-        memory: 512Mi # Requests Minimum memory=512Mi per gpu node
-    serviceAccount:
-      create: false
-  networkPolicy:
-    enabled: false
-  serviceAccount:
-    create: false
-  nodeSelector: 
-    beta.kubernetes.io/instance-type: standard-v3
-service:
-  type: ClusterIP
 worker:
-  affinity: {}
   annotations: {}
   args: []
   command: []
@@ -156,7 +88,19 @@ worker:
       cpu: '{{ tpl .Values.worker.resources.limits.cpu . }}'
       memory: '{{ tpl .Values.worker.resources.limits.memory . }}'
       nvidia.com/gpu: "8"
-  securityContext: {}
+  nodeSelector: 
+    beta.kubernetes.io/instance-type: gpu-h100-b
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: beta.kubernetes.io/instance-type
+            operator: In
+            values:
+            - gpu-h100-b
+  securityContext:
+    privileged: true
   serviceAccountName: ""
   sidecarContainers: []
   tolerations:
@@ -169,3 +113,128 @@ worker:
   volumes:
   - emptyDir: {}
     name: log-volume
+  - name: node-mount
+    hostPath:
+      path: /shared
+      type: Directory
+head:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: beta.kubernetes.io/instance-type
+            operator: In
+            values:
+            - standard-v2
+  annotations: {}
+  args: []
+  command: []
+  containerEnv:
+  - name: RAY_REDIS_ADDRESS
+    value: '{{ .Release.Name }}-redis-master:6379'
+  - name: NVIDIA_VISIBLE_DEVICES
+    value: "void"
+  enableInTreeAutoscaling: true
+  envFrom: []
+  headService: {}
+  labels: {}
+  nodeSelector: 
+    beta.kubernetes.io/instance-type: standard-v2
+  tolerations:
+  - key: "beta.kubernetes.io/instance-type"
+    operator: "Equal"
+    value: "standard-v2"
+    effect: "NoSchedule"
+  rayStartParams:
+    dashboard-host: 0.0.0.0
+  resources:
+    limits:
+      cpu: "4"
+      memory: 8Gi
+    requests:
+      cpu: '{{ .Values.head.resources.limits.cpu }}'
+      memory: '{{ .Values.head.resources.limits.memory }}'
+  securityContext: {}
+  serviceAccountName: ""
+  sidecarContainers: []
+  volumeMounts:
+  - mountPath: /tmp/ray
+    name: log-volume
+  - mountPath: /shared
+    name: node-mount
+  volumes:
+  - emptyDir: {}
+    name: log-volume
+  - name: node-mount
+    hostPath:
+      path: /shared
+      type: Directory
+image:
+  pullPolicy: IfNotPresent
+  repository: cr.nemax.nebius.cloud/yc-marketplace/nebius/ray-cluster/rayproject/ray-ml1713900777304275129011842529120435612759099215098
+  tag: 2.9.3-gpu
+imagePullSecrets: []
+kuberay-operator:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: beta.kubernetes.io/instance-type
+            operator: NotIn
+            values:
+            - gpu-h100-b
+  image:
+    pullPolicy: IfNotPresent
+    repository: cr.nemax.nebius.cloud/yc-marketplace/nebius/ray-cluster/kuberay/operator1713900777304275129011842529120435612759099215098
+    tag: v1.1.0
+  singleNamespaceInstall: true
+  nodeSelector: 
+    beta.kubernetes.io/instance-type: standard-v2
+nameOverride: kuberay
+redis:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: beta.kubernetes.io/instance-type
+            operator: In
+            values:
+            - standard-v2
+  architecture: standalone
+  auth:
+    enabled: false
+  image:
+    pullPolicy: IfNotPresent
+    registry: cr.nemax.nebius.cloud/yc-marketplace
+    repository: nebius/ray-cluster/redis1713900777304275129011842529120435612759099215098
+    tag: 7.2.4-debian-12-r9
+  master:
+    persistence:
+      size: 8Gi
+      storageClass: nebius-network-ssd
+    persistentVolumeClaimRetentionPolicy:
+      enabled: true
+      whenDeleted: Delete
+      whenScaled: Retain
+    resources:
+      limits:
+        cpu: "2" # limits Minimum cpu=4 per gpu node
+        memory: 4Gi # limits Minimum memory=8Gi per gpu node
+      requests:
+        cpu: "1" # Requests Minimum cpu=1 per gpu node
+        memory: 512Mi # Requests Minimum memory=512Mi per gpu node
+    serviceAccount:
+      create: false
+  networkPolicy:
+    enabled: false
+  serviceAccount:
+    create: false
+  nodeSelector:
+    beta.kubernetes.io/instance-type: standard-v2
+service:
+  type: ClusterIP

--- a/kubernetes/terraform/kuberay/helm/ray-values.yaml
+++ b/kubernetes/terraform/kuberay/helm/ray-values.yaml
@@ -128,6 +128,8 @@ redis:
     enabled: false
   serviceAccount:
     create: false
+  nodeSelector: 
+    beta.kubernetes.io/instance-type: standard-v3
 service:
   type: ClusterIP
 worker:

--- a/kubernetes/terraform/kuberay/main.tf
+++ b/kubernetes/terraform/kuberay/main.tf
@@ -16,7 +16,7 @@ resource "helm_release" "kuberay-operator" {
   }
   set {
     name  = "worker.minReplicas"
-    value = var.gpu_workers
+    value = 1
   }
 
 }


### PR DESCRIPTION
Added fix for head pod getting GPUs where it shouldn't:
- name: NVIDIA_VISIBLE_DEVICES value: "void" Fix is based on this ray-project public repo issue: TLDR - looks like GPU operator bypassing gpus to head pod; https://github.com/ray-project/ray/issues/29753

Added nodeSelectors for redis and head pod, so by default they will 'eat' resources only from CPU nodes, based on labels: beta.kubernetes.io/instance-type: standard-v3